### PR TITLE
feat: injectable ajax lib

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,12 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, DoCheck, HostListener } from '@angular/core';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html'
 })
-export class AppComponent {
+export class AppComponent implements DoCheck {
   hidden = true;
+  changes = 0;
 
   @HostListener('dragenter', ['$event'])
   @HostListener('dragover', ['$event'])
@@ -16,5 +17,8 @@ export class AppComponent {
       event.dataTransfer.effectAllowed = 'none';
       event.dataTransfer.dropEffect = 'none';
     }
+  }
+  ngDoCheck(): void {
+    // console.log('change-detection ', this.changes++);
   }
 }

--- a/src/app/digest.ts
+++ b/src/app/digest.ts
@@ -1,0 +1,30 @@
+import { b64, RequestOptions, Uploader } from 'ngx-uploadx';
+
+const hasher = {
+  isSupported: window.crypto && !!window.crypto.subtle,
+  async sha(data: ArrayBuffer): Promise<string> {
+    return this.hex(await crypto.subtle.digest('SHA-1', data));
+  },
+  getDigest(body: Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = async () => resolve(await this.sha(reader.result as ArrayBuffer));
+      reader.onerror = reject;
+      reader.readAsArrayBuffer(body);
+    });
+  },
+  hex(buffer: ArrayBuffer): string {
+    return [...new Uint8Array(buffer)].map(b => b.toString(16).padStart(2, '0')).join('');
+  }
+};
+
+export async function injectDigestHeader(
+  this: Uploader,
+  req: RequestOptions
+): Promise<RequestOptions> {
+  if (hasher.isSupported && req.body instanceof Blob) {
+    const sha = await hasher.getDigest(req.body);
+    Object.assign(req.headers, { Digest: 'sha=' + b64.encode(sha) });
+  }
+  return req;
+}

--- a/src/app/on-push/on-push.component.ts
+++ b/src/app/on-push/on-push.component.ts
@@ -1,16 +1,9 @@
 import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
-import {
-  b64,
-  RequestOptions,
-  Uploader,
-  UploaderX,
-  UploadState,
-  UploadxOptions,
-  UploadxService
-} from 'ngx-uploadx';
+import { Uploader, UploadState, UploadxOptions, UploadxService } from 'ngx-uploadx';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { AuthService } from '../auth.service';
+import { injectDigestHeader } from '../digest';
 
 @Component({
   selector: 'app-on-push',
@@ -23,7 +16,9 @@ export class OnPushComponent implements OnDestroy {
   options: UploadxOptions = {
     endpoint: `${environment.api}/files?uploadType=uploadx`,
     prerequest: injectDigestHeader,
-    token: this.tokenGetter.bind(this)
+    token: async (httpStatus?: number): Promise<string> => {
+      return httpStatus === 401 ? await this.auth.renewToken().toPromise() : this.auth.accessToken;
+    }
   };
 
   constructor(private uploadService: UploadxService, private auth: AuthService) {
@@ -46,36 +41,4 @@ export class OnPushComponent implements OnDestroy {
   uploadAll(): void {
     this.uploadService.control({ action: 'upload' });
   }
-
-  async tokenGetter(httpStatus?: number): Promise<string> {
-    return httpStatus === 401 ? await this.auth.renewToken().toPromise() : this.auth.accessToken;
-  }
-}
-
-const hasher = {
-  isSupported: window.crypto && !!window.crypto.subtle,
-  async sha(data: ArrayBuffer): Promise<string> {
-    return this.hex(await crypto.subtle.digest('SHA-1', data));
-  },
-  getDigest(body: Blob): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = async () => resolve(await this.sha(reader.result as ArrayBuffer));
-      reader.onerror = reject;
-      reader.readAsArrayBuffer(body);
-    });
-  },
-  hex(buffer: ArrayBuffer): string {
-    return [...new Uint8Array(buffer)].map(b => b.toString(16).padStart(2, '0')).join('');
-  }
-};
-
-async function injectDigestHeader(this: UploaderX, req: RequestOptions): Promise<RequestOptions> {
-  if (hasher.isSupported && req.method === 'PUT' && req.body instanceof Blob) {
-    const headers = req.headers || {};
-    const sha = await hasher.getDigest(req.body);
-    headers.Digest = 'sha=' + b64.encode(sha);
-    console.log(sha, headers.Digest);
-  }
-  return req;
 }

--- a/src/uploadx/lib/ajax.ts
+++ b/src/uploadx/lib/ajax.ts
@@ -1,0 +1,94 @@
+import { InjectionToken } from '@angular/core';
+import { RequestOptions } from './interfaces';
+
+export class RequestCanceler {
+  onCancel: () => void = () => {};
+
+  cancel(): void {
+    this.onCancel();
+    this.onCancel = () => {};
+  }
+}
+
+export interface AjaxRequestConfig extends RequestOptions {
+  data: BodyInit | null;
+  responseType?: 'json' | 'text';
+  onUploadProgress?: (evt: ProgressEvent) => void;
+  withCredentials: boolean;
+  canceler: RequestCanceler;
+  validateStatus: (status: number) => boolean;
+}
+
+export interface Ajax {
+  request: <T = string>(
+    config: AjaxRequestConfig
+  ) => Promise<{ data: T; status: number; headers: Record<string, string> }>;
+}
+
+export const ajax: Ajax = {
+  request: <T = string>({
+    method,
+    data,
+    headers = {},
+    url = '/upload',
+    responseType,
+    canceler,
+    onUploadProgress,
+    withCredentials = false,
+    validateStatus = () => true
+  }: AjaxRequestConfig): Promise<{
+    data: T;
+    status: number;
+    headers: Record<string, string>;
+  }> => {
+    const xhr = new XMLHttpRequest();
+    canceler.onCancel = () => xhr && xhr.readyState !== xhr.DONE && xhr.abort();
+    return new Promise((resolve, reject) => {
+      const response = { data: (null as unknown) as T, status: 0, headers: {} };
+      xhr.open(method, url, true);
+      responseType && (xhr.responseType = responseType);
+      withCredentials && (xhr.withCredentials = true);
+      Object.keys(headers).forEach(key => xhr.setRequestHeader(key, String(headers[key])));
+      onUploadProgress && (xhr.upload.onprogress = onUploadProgress);
+      xhr.onerror = xhr.ontimeout = xhr.onabort = evt => {
+        ((xhr as unknown) as null) = null;
+        return reject({ ...response, error: evt.type });
+      };
+      xhr.onload = () => {
+        response.status = xhr.status;
+        response.data = getResponseBody<T>(xhr);
+        response.headers = getResponseHeaders(xhr);
+        ((xhr as unknown) as null) = null;
+        return validateStatus(response.status) ? resolve(response) : reject(response);
+      };
+      xhr.send(data);
+    });
+  }
+};
+
+function getResponseHeaders(xhr: XMLHttpRequest): Record<string, string> {
+  const rows = xhr.getAllResponseHeaders().split('\r\n');
+  return rows.reduce((headers: Record<string, string>, current) => {
+    const [name, value] = current.split(': ');
+    name && (headers[name] = value);
+    return headers;
+  }, {});
+}
+
+function getResponseBody<T = string>(
+  xhr: XMLHttpRequest,
+  responseType?: XMLHttpRequestResponseType
+): T {
+  let body = 'response' in (xhr as XMLHttpRequest) ? xhr.response : xhr.responseText;
+  if (body && responseType === 'json' && typeof body === 'string') {
+    try {
+      body = JSON.parse(body);
+    } catch {}
+  }
+  return body;
+}
+
+export const UPLOADX_AJAX: InjectionToken<Ajax> = new InjectionToken('uploadx.ajax', {
+  factory: () => ajax,
+  providedIn: 'root'
+});

--- a/src/uploadx/lib/interfaces.ts
+++ b/src/uploadx/lib/interfaces.ts
@@ -1,13 +1,11 @@
 import { InjectionToken } from '@angular/core';
+import { Ajax } from './ajax';
 import { RetryConfig } from './error-handler';
 import { Uploader } from './uploader';
 
 export type Primitive = null | boolean | number | string;
 
-export type ResponseBody =
-  | Primitive
-  | { [key: number]: ResponseBody } // for older ts versions
-  | { [key: string]: ResponseBody };
+export type ResponseBody = string | object | null;
 
 export type RequestHeaders = Record<string, Primitive | Primitive[]>;
 
@@ -56,6 +54,9 @@ export interface UploadState {
 
   /** HTTP response status code */
   readonly responseStatus: number;
+
+  /** HTTP response headers */
+  readonly responseHeaders: Record<string, string>;
 
   /** File size in bytes */
   readonly size: number;
@@ -115,7 +116,8 @@ export interface UploaderOptions extends UploadItem {
 export type UploaderClass = new (
   file: File,
   options: UploaderOptions,
-  stateChange: (evt: UploadEvent) => void
+  stateChange: (evt: UploadEvent) => void,
+  ajax: Ajax
 ) => Uploader;
 
 /**

--- a/src/uploadx/lib/tus.spec.ts
+++ b/src/uploadx/lib/tus.spec.ts
@@ -1,3 +1,4 @@
+import { Ajax } from 'ngx-uploadx';
 import { Tus } from './tus';
 
 // tslint:disable: no-any
@@ -7,7 +8,7 @@ describe('getFileUrl', () => {
   let req: jasmine.Spy;
   let getValueFromResponse: jasmine.Spy;
   it('should set headers', async () => {
-    upx = new Tus(fileWithType, {}, () => {});
+    upx = new Tus(fileWithType, {}, () => {}, {} as Ajax);
     req = spyOn<any>(upx, 'request').and.callFake(({ headers }: any) => {
       expect(headers['Upload-Metadata']).toContain('name');
       expect(headers['Upload-Length']).toEqual('6');
@@ -25,7 +26,7 @@ describe('sendFileContent', () => {
   let req: jasmine.Spy;
   let getOffsetFromResponse: jasmine.Spy;
   it('should set Upload-Offset header', async () => {
-    upx = new Tus(fileWithType, {}, () => {});
+    upx = new Tus(fileWithType, {}, () => {}, {} as Ajax);
     req = spyOn<any>(upx, 'request').and.callFake(({ headers }: any) => {
       expect(headers['Content-Type']).toEqual('application/offset+octet-stream');
       expect(headers['Upload-Offset']).toEqual('0');

--- a/src/uploadx/lib/uploaderx.spec.ts
+++ b/src/uploadx/lib/uploaderx.spec.ts
@@ -1,3 +1,4 @@
+import { Ajax } from 'ngx-uploadx';
 import { getRangeEnd, UploaderX } from './uploaderx';
 // tslint:disable: no-any
 
@@ -9,7 +10,7 @@ describe('getFileUrl', () => {
   let req: jasmine.Spy;
   let getValueFromResponse: jasmine.Spy;
   it('should set headers', async () => {
-    upx = new UploaderX(fileWithType, {}, () => {});
+    upx = new UploaderX(fileWithType, {}, () => {}, {} as Ajax);
     req = spyOn<any>(upx, 'request').and.callFake(({ headers }: any) => {
       expect(headers['X-Upload-Content-Type']).toEqual('text/plain');
       expect(headers['X-Upload-Content-Length']).toEqual('6');
@@ -22,7 +23,7 @@ describe('getFileUrl', () => {
     expect(getValueFromResponse).toHaveBeenCalled();
   });
   it('should set default type header', async () => {
-    upx = new UploaderX(fileWithoutType, {}, () => {});
+    upx = new UploaderX(fileWithoutType, {}, () => {}, {} as Ajax);
     req = spyOn<any>(upx, 'request').and.callFake(({ headers }: any) => {
       expect(headers['X-Upload-Content-Type']).toEqual('application/octet-stream');
       expect(headers['X-Upload-Content-Length']).toEqual('0');
@@ -41,7 +42,7 @@ describe('sendFileContent', () => {
   let req: jasmine.Spy;
   let getValueFromResponse: jasmine.Spy;
   it('should set Content-Range header', async () => {
-    upx = new UploaderX(fileWithType, {}, () => {});
+    upx = new UploaderX(fileWithType, {}, () => {}, {} as Ajax);
     req = spyOn<any>(upx, 'request').and.callFake(({ headers }: any) => {
       expect(headers['Content-Type']).toEqual('application/octet-stream');
       expect(headers['Content-Range']).toEqual('bytes 0-5/6');

--- a/src/uploadx/lib/uploaderx.ts
+++ b/src/uploadx/lib/uploaderx.ts
@@ -8,7 +8,7 @@ import { resolveUrl } from './utils';
  * @see {@link https://developers.google.com/drive/api/v3/manage-uploads#resumable|Google Drive API documentation}
  */
 export class UploaderX extends Uploader {
-  responseType = 'json' as XMLHttpRequestResponseType;
+  responseType = 'json' as 'json';
 
   async getFileUrl(): Promise<string> {
     const headers = {

--- a/src/uploadx/lib/uploadx.service.spec.ts
+++ b/src/uploadx/lib/uploadx.service.spec.ts
@@ -1,4 +1,5 @@
 import { NgZone } from '@angular/core';
+import { Ajax } from 'ngx-uploadx';
 import { UploadAction, UploadxOptions } from './interfaces';
 import { UploaderX } from './uploaderx';
 import { UploadxService } from './uploadx.service';
@@ -41,7 +42,7 @@ const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 describe('UploadxService', () => {
   let service: UploadxService;
   beforeEach(() => {
-    service = new UploadxService(null, new NgZone({}));
+    service = new UploadxService(null, {} as Ajax, new NgZone({}));
   });
 
   it('should set default options', () => {

--- a/src/uploadx/lib/uploadx.service.ts
+++ b/src/uploadx/lib/uploadx.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, NgZone, OnDestroy, Optional } from '@angular/core';
 import { fromEvent, Observable, Subject, Subscription } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
+import { Ajax, UPLOADX_AJAX } from './ajax';
 import {
   UploaderClass,
   UploadState,
@@ -49,6 +50,7 @@ export class UploadxService implements OnDestroy {
 
   constructor(
     @Optional() @Inject(UPLOADX_OPTIONS) options: UploadxOptions | null,
+    @Inject(UPLOADX_AJAX) readonly ajax: Ajax,
     private ngZone: NgZone
   ) {
     this.options = Object.assign({}, defaultOptions, options);
@@ -147,7 +149,7 @@ export class UploadxService implements OnDestroy {
   };
 
   private addUploaderInstance(file: File, options: ServiceFactoryOptions): void {
-    const uploader = new options.uploaderClass(file, options, this.stateChange);
+    const uploader = new options.uploaderClass(file, options, this.stateChange, this.ajax);
     this.queue.push(uploader);
     uploader.status = options.autoUpload && window.navigator.onLine ? 'queue' : 'added';
   }

--- a/src/uploadx/public-api.ts
+++ b/src/uploadx/public-api.ts
@@ -1,4 +1,5 @@
 export * from './lib/error-handler';
+export * from './lib/ajax';
 export * from './lib/interfaces';
 export * from './lib/tus';
 export * from './lib/uploader';

--- a/uploader-examples/multipart-form-data.ts
+++ b/uploader-examples/multipart-form-data.ts
@@ -11,7 +11,7 @@ import { resolveUrl, Uploader } from 'ngx-uploadx';
  *   };
  */
 export class MultiPartFormData extends Uploader {
-  responseType = 'json' as XMLHttpRequestResponseType;
+  responseType = 'json' as 'json';
 
   async getFileUrl(): Promise<string> {
     this.offset = 0;

--- a/uploader-examples/multipart-multer.ts
+++ b/uploader-examples/multipart-multer.ts
@@ -12,7 +12,7 @@ import { Uploader } from 'ngx-uploadx';
  *   };
  */
 export class Multer extends Uploader {
-  responseType = 'json' as XMLHttpRequestResponseType;
+  responseType = 'json' as 'json';
 
   async getFileUrl(): Promise<string> {
     this.offset = 0;


### PR DESCRIPTION
Allow using third-party packages for requests.

```ts
// Axios example: 

const instance = Axios.create({
  /* put axios common config here */
});
class AxiosRequest implements Ajax {
  request = (config: AjaxRequestConfig) => {
    const cancelToken = new Axios.CancelToken(c => (config.canceler.onCancel = c));
    return instance.request({ ...config, cancelToken });
  };
}
const axiosRequestFactory = (): Ajax => new AxiosRequest();

@NgModule({
  declarations: [
  //  ...
  ],
  imports: [
  // ...
    UploadxModule
  ],
  providers: [{ provide: UPLOADX_AJAX, useFactory: axiosRequestFactory }],
  bootstrap: [AppComponent],
  exports: []
})
export class AppModule {}
```
