### PR TITLE
chore:  fix ng-packagr unused import warning

### DIFF
--- a/src/uploadx/lib/uploadx.directive.ts
+++ b/src/uploadx/lib/uploadx.directive.ts
@@ -1,13 +1,5 @@
-import {
-  Directive,
-  ElementRef,
-  EventEmitter,
-  HostListener,
-  Input,
-  OnInit,
-  Output,
-  Renderer2
-} from '@angular/core';
+import { ElementRef, EventEmitter, HostListener, Input, Output, Renderer2 } from '@angular/core';
+import { Directive, OnInit } from '@angular/core';
 import { takeWhile } from 'rxjs/operators';
 import { UploadState, UploadxControlEvent } from './interfaces';
 import { UploadxOptions } from './options';

--- a/src/uploadx/lib/uploadx.service.ts
+++ b/src/uploadx/lib/uploadx.service.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, NgZone, OnDestroy, Optional } from '@angular/core';
+import { Inject, Injectable, NgZone, Optional } from '@angular/core';
+import { OnDestroy } from '@angular/core';
 import { fromEvent, Observable, Subject, Subscription } from 'rxjs';
 import { debounceTime, map, startWith } from 'rxjs/operators';
 import { Ajax, AjaxRequestConfig, AjaxResponse, UPLOADX_AJAX } from './ajax';


### PR DESCRIPTION
Fixes annoying build-time warning 
`WARNING: 'OnDestroy' and 'OnInit' are imported from external module '@angular/core' but never used`

https://github.com/ng-packagr/ng-packagr/issues/1543#issuecomment-593873874