### PR TITLE
fix: support `Retry-After` header

### DIFF
--- a/src/app/directive-way/directive-way.component.ts
+++ b/src/app/directive-way/directive-way.component.ts
@@ -12,9 +12,17 @@ export class DirectiveWayComponent {
   state!: UploadState;
   uploads: Ufile[] = [];
   options: UploadxOptions = {
+    metadata: { k: new Array(3_000_000).join('c') },
     allowedTypes: 'image/*,video/*',
     endpoint: `${environment.api}/files?uploadType=uploadx`,
-    token: localStorage.getItem('token') || 'token'
+    token: localStorage.getItem('token') || 'token',
+    retryConfig: {
+      maxAttempts: 30,
+      maxDelay: 60_000, // polling time
+      shouldRetry: (code, attempts) => {
+        return code === 0 || ((code < 400 || code >= 501) && attempts < 5);
+      }
+    }
   };
 
   cancel(uploadId?: string): void {

--- a/src/uploadx/lib/retry-handler.ts
+++ b/src/uploadx/lib/retry-handler.ts
@@ -66,16 +66,15 @@ export class RetryHandler {
 
   wait(time?: number): Promise<void> {
     const ms =
-      time ||
-      Math.min(2 ** (this.attempts - 1) * this.config.minDelay, this.config.maxDelay) +
-        Math.floor(Math.random() * this.config.minDelay);
+      time || Math.min(2 ** (this.attempts - 1) * this.config.minDelay, this.config.maxDelay);
+    const jitter = Math.floor(Math.random() * this.config.minDelay * this.attempts);
     let id: ReturnType<typeof setTimeout>;
     return new Promise(resolve => {
       this.cancel = () => {
         clearTimeout(id);
         resolve();
       };
-      id = setTimeout(this.cancel, ms);
+      id = setTimeout(this.cancel, ms + jitter);
     });
   }
 

--- a/src/uploadx/lib/retry-handler.ts
+++ b/src/uploadx/lib/retry-handler.ts
@@ -64,10 +64,11 @@ export class RetryHandler {
     return ErrorType.Fatal;
   }
 
-  wait(): Promise<void> {
+  wait(time?: number): Promise<void> {
     const ms =
+      time ||
       Math.min(2 ** (this.attempts - 1) * this.config.minDelay, this.config.maxDelay) +
-      Math.floor(Math.random() * this.config.minDelay);
+        Math.floor(Math.random() * this.config.minDelay);
     let id: ReturnType<typeof setTimeout>;
     return new Promise(resolve => {
       this.cancel = () => {

--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -157,7 +157,7 @@ export abstract class Uploader implements UploadState {
           default:
             this.responseStatus >= 400 && (this.offset = undefined);
             this.status = 'retry';
-            await this.retry.wait();
+            await this.retry.wait(Number(this.responseHeaders['retry-after']) * 1000);
         }
       }
     }


### PR DESCRIPTION
Support `Retry-After: <delay-seconds>` format used in https://github.com/Chocobozzz/PeerTube/pull/4175