### PR TITLE
fix: add timeout option

### DIFF
--- a/src/app/tus/tus.component.ts
+++ b/src/app/tus/tus.component.ts
@@ -17,7 +17,6 @@ export class TusComponent {
     allowedTypes: 'image/*,video/*',
     endpoint: `${environment.api}/files?uploadType=tus`,
     uploaderClass: Tus,
-    chunkSize: 0,
     authorize: async req => {
       const token = await this.authService.getTokenAsPromise();
       req.headers.Authorization = `Token ${token}`;

--- a/src/app/tus/tus.component.ts
+++ b/src/app/tus/tus.component.ts
@@ -17,6 +17,7 @@ export class TusComponent {
     allowedTypes: 'image/*,video/*',
     endpoint: `${environment.api}/files?uploadType=tus`,
     uploaderClass: Tus,
+    chunkSize: 0,
     authorize: async req => {
       const token = await this.authService.getTokenAsPromise();
       req.headers.Authorization = `Token ${token}`;
@@ -24,7 +25,8 @@ export class TusComponent {
     },
     metadata(file): Record<string, string> {
       return { original_name: file.name };
-    }
+    },
+    retryConfig: { timeout: 10_000 }
   };
   constructor(private authService: AuthService) {}
   cancel(uploadId?: string): void {

--- a/src/uploadx/lib/ajax.ts
+++ b/src/uploadx/lib/ajax.ts
@@ -38,6 +38,7 @@ export class UploadxAjax {
     responseType,
     canceler,
     onUploadProgress,
+    timeout = 0,
     withCredentials = false,
     validateStatus = status => status < 400 && status >= 200
   }: AjaxRequestConfig): Promise<AjaxResponse<T>> => {
@@ -45,6 +46,7 @@ export class UploadxAjax {
     canceler && (canceler.onCancel = () => xhr && xhr.readyState !== xhr.DONE && xhr.abort());
     return new Promise((resolve, reject) => {
       xhr.open(method, url, true);
+      xhr.timeout = timeout;
       withCredentials && (xhr.withCredentials = true);
       responseType && (xhr.responseType = responseType);
       responseType === 'json' && !headers.Accept && (headers.Accept = 'application/json');

--- a/src/uploadx/lib/retry-handler.ts
+++ b/src/uploadx/lib/retry-handler.ts
@@ -20,6 +20,7 @@ export interface RetryConfig {
   shouldRetry?: ShouldRetryFunction;
   minDelay?: number;
   maxDelay?: number;
+  timeout?: number;
 }
 
 const defaultRetryConfig: Required<RetryConfig> = {
@@ -31,7 +32,8 @@ const defaultRetryConfig: Required<RetryConfig> = {
     return code < 400 || code >= 500 || this.shouldRetryCodes.indexOf(code) !== -1;
   },
   minDelay: 500,
-  maxDelay: 50000
+  maxDelay: 50000,
+  timeout: 0
 };
 
 /**

--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -187,7 +187,8 @@ export abstract class Uploader implements UploadState {
       responseType: this.responseType,
       withCredentials: !!this.options.withCredentials,
       canceler: this.canceler,
-      validateStatus: () => true
+      validateStatus: () => true,
+      timeout: this.retry.config.timeout
     };
     if (body && typeof body !== 'string') {
       ajaxRequestConfig.onUploadProgress = this.onProgress();

--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -155,6 +155,7 @@ export abstract class Uploader implements UploadState {
             await this.updateToken();
             break;
           default:
+            // force getOffset() on http errors and repeat request on network errors
             this.responseStatus >= 400 && (this.offset = undefined);
             this.status = 'retry';
             await this.retry.wait(Number(this.responseHeaders['retry-after']) * 1000);


### PR DESCRIPTION
Allow set  interval after which unfinished requests must be retried
```ts
  options: UploadxOptions = {
    endpoint: `${environment.api}/files?uploadType=tus`,
    retryConfig: { timeout: 10_000 }
```
will probably closes  #310 by @siovene