### PR TITLE
fix: no range/offset retry delay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ export class AppHomeComponent {
   - `shouldRetry` Overrides the built-in function that determines whether the operation should be retried
   - `minDelay` Minimum (initial) retry interval. Default value: `500`
   - `maxDelay` Maximum retry interval. Default value: `50_000`
+  - `onBusyDelay` Delay used between retries for non-error responses with missing range/offset
   - `timeout` Time interval after which unfinished requests must be retried
 
 - `token` Authorization token as a `string` or function returning a `string` or `Promise<string>`

--- a/src/uploadx/lib/retry-handler.ts
+++ b/src/uploadx/lib/retry-handler.ts
@@ -18,8 +18,13 @@ export interface RetryConfig {
   shouldRetryCodes?: number[];
   /** Overrides the built-in function that determines whether the operation should be repeated */
   shouldRetry?: ShouldRetryFunction;
+  /** The minimum retry delay */
   minDelay?: number;
+  /** The maximum retry delay */
   maxDelay?: number;
+  /** Delay used between retries for non-error responses with missing range/offset */
+  onBusyDelay?: number;
+  /** Time interval after which hanged requests must be retried */
   timeout?: number;
 }
 
@@ -33,6 +38,7 @@ const defaultRetryConfig: Required<RetryConfig> = {
   },
   minDelay: 500,
   maxDelay: 50000,
+  onBusyDelay: 1000,
   timeout: 0
 };
 

--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -139,6 +139,7 @@ export abstract class Uploader implements UploadState {
           this.progress = 100;
           this.status = 'complete';
         }
+        !this.offset && (await this.retry.wait(Number(this.responseHeaders['retry-after']) * 1000));
       } catch (e) {
         e instanceof Error && console.error(e);
         if (this.status !== 'uploading') {


### PR DESCRIPTION
Prevents auto-DDoS for responses with missing or  invalid range/offset and also improves support for long post-upload operations with polling