### PR TITLE
fix: limit resumable upload lifetime

### DIFF
--- a/src/app/directive-way/directive-way.component.ts
+++ b/src/app/directive-way/directive-way.component.ts
@@ -18,6 +18,7 @@ export class DirectiveWayComponent {
     token: this.authService.getAccessToken(),
     maxChunkSize: 1024 * 1024 * 8,
     storeIncompleteUploadUrl: true,
+    storeIncompleteHours: 24,
     retryConfig: {
       maxAttempts: 30,
       maxDelay: 60_000,

--- a/src/uploadx/lib/interfaces.ts
+++ b/src/uploadx/lib/interfaces.ts
@@ -97,7 +97,7 @@ interface UploadItem {
    */
   metadata?: Metadata | ((file: File) => Metadata);
   /**
-   * Authorization  token as a `string` or function returning a `string` or `Promise<string>`
+   * Authorization token as a `string` or function returning a `string` or `Promise<string>`
    */
   token?: string | ((httpStatus: number) => string | Promise<string>);
 }
@@ -125,11 +125,6 @@ export interface UploaderOptions extends UploadItem {
    * Function used to apply authorization token
    */
   authorize?: AuthorizeRequest;
-  /**
-   * Keep an incomplete upload url to allow resuming after browser restart
-   * @defaultValue true
-   */
-  storeIncompleteUploadUrl?: boolean;
 }
 
 export type UploaderClass = new (

--- a/src/uploadx/lib/options.ts
+++ b/src/uploadx/lib/options.ts
@@ -30,6 +30,16 @@ export interface UploadxOptions extends UploaderOptions {
    * @defaultValue true
    */
   multiple?: boolean;
+  /**
+   * Keep an incomplete upload url to allow resuming after browser restart
+   * @deprecated use storeIncompleteHours = 0 to disable
+   */
+  storeIncompleteUploadUrl?: boolean;
+  /**
+   * Retention time for incomplete uploads
+   * @defaultValue 24
+   */
+  storeIncompleteHours?: number;
 }
 
 export interface UploadxFactoryOptions extends UploadxOptions {
@@ -38,6 +48,8 @@ export interface UploadxFactoryOptions extends UploadxOptions {
   concurrency: number;
   uploaderClass: UploaderClass;
   authorize: AuthorizeRequest;
+  storeIncompleteUploadUrl: boolean;
+  storeIncompleteHours: number;
 }
 
 const defaultOptions: UploadxFactoryOptions = {
@@ -48,7 +60,9 @@ const defaultOptions: UploadxFactoryOptions = {
   authorize: (req, token) => {
     token && (req.headers.Authorization = `Bearer ${token}`);
     return req;
-  }
+  },
+  storeIncompleteUploadUrl: true,
+  storeIncompleteHours: 24
 };
 
 export const UPLOADX_FACTORY_OPTIONS = new InjectionToken<UploadxFactoryOptions>(

--- a/src/uploadx/lib/store.ts
+++ b/src/uploadx/lib/store.ts
@@ -1,30 +1,51 @@
-class Store {
-  prefix = 'UPLOADX-V3.0-';
+const HOUR = 1000 * 60 * 60;
 
-  set(key: string, value: string): void {
-    localStorage.setItem(this.prefix + key, value);
+export class Store<T = string> {
+  private ttl = 24 * HOUR;
+  constructor(readonly prefix = 'UPLOADX-v4.0-') {}
+
+  set(key: string, value: T): void {
+    this.ttl &&
+      localStorage.setItem(this.prefix + key, JSON.stringify([value, Date.now() + this.ttl]));
   }
 
-  get(key: string): string | null {
-    return localStorage.getItem(this.prefix + key);
+  get(key: string): T | null {
+    const item = localStorage.getItem(this.prefix + key);
+    if (item) {
+      const [value, expires] = JSON.parse(item);
+      return value && expires ? value : null;
+    }
+    return null;
   }
 
   delete(key: string): void {
     localStorage.removeItem(this.prefix + key);
   }
 
-  clear(): void {
-    Object.keys(localStorage).forEach(
-      key => key.indexOf(this.prefix) === 0 && localStorage.removeItem(key)
-    );
+  clear(maxAgeHours = 0): void {
+    this.ttl = maxAgeHours * HOUR;
+    const now = Date.now();
+    this.keys().forEach(key => {
+      const item = localStorage.getItem(key);
+      if (item && maxAgeHours) {
+        const [, expires] = JSON.parse(item);
+        now > Number(expires) && localStorage.removeItem(key);
+      } else {
+        localStorage.removeItem(key);
+      }
+    });
+  }
+
+  private keys(): string[] {
+    return Object.keys(localStorage).filter(key => key.indexOf(this.prefix) === 0);
   }
 }
 
 export const store = isLocalStorageAvailable() ? new Store() : new Map<string, string>();
 
-function isLocalStorageAvailable(): boolean {
+export function isLocalStorageAvailable(): boolean {
   try {
-    const key = 'uploadxLocalStorageTest';
+    const key = 'LocalStorageTest';
     const value = 'value';
     localStorage.setItem(key, value);
     const getValue = localStorage.getItem(key);

--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -59,14 +59,13 @@ export abstract class Uploader implements UploadState {
   private startTime!: number;
   private _token!: string;
   private _url = '';
-  private storeEnabled = this.options.storeIncompleteUploadUrl !== false;
 
   get url(): string {
-    return this._url || (this.storeEnabled && store.get(this.uploadId)) || '';
+    return this._url || store.get(this.uploadId) || '';
   }
 
   set url(value: string) {
-    this._url !== value && this.storeEnabled && store.set(this.uploadId, value);
+    this._url !== value && store.set(this.uploadId, value);
     this._url = value;
   }
 
@@ -262,7 +261,7 @@ export abstract class Uploader implements UploadState {
     return { start, end, body };
   }
 
-  private cleanup = () => this.storeEnabled && store.delete(this.uploadId);
+  private cleanup = () => store.delete(this.uploadId);
 
   private onProgress(): (evt: ProgressEvent) => void {
     let throttle: ReturnType<typeof setTimeout> | undefined;

--- a/src/uploadx/lib/uploadx.service.spec.ts
+++ b/src/uploadx/lib/uploadx.service.spec.ts
@@ -8,6 +8,8 @@ import { UploaderX } from './uploaderx';
 import { UploadxService } from './uploadx.service';
 
 const defaultOptions: UploadxFactoryOptions = {
+  storeIncompleteHours: 1,
+  storeIncompleteUploadUrl: true,
   endpoint: '/upload',
   autoUpload: true,
   concurrency: 2,

--- a/src/uploadx/lib/uploadx.service.ts
+++ b/src/uploadx/lib/uploadx.service.ts
@@ -12,6 +12,7 @@ import {
   UploadxFactoryOptions,
   UploadxOptions
 } from './options';
+import { store } from './store';
 import { Uploader } from './uploader';
 import { isIOS, pick } from './utils';
 
@@ -40,11 +41,6 @@ export class UploadxService implements OnDestroy {
   private readonly eventsStream: Subject<UploadState> = new Subject();
   private subs: Subscription[] = [];
 
-  /** Upload status events */
-  get events(): Observable<UploadState> {
-    return this.eventsStream.asObservable();
-  }
-
   constructor(
     @Optional() @Inject(UPLOADX_OPTIONS) options: UploadxOptions | null,
     @Inject(UPLOADX_FACTORY_OPTIONS) defaults: UploadxFactoryOptions,
@@ -59,6 +55,11 @@ export class UploadxService implements OnDestroy {
         fromEvent(window, 'offline').subscribe(() => this.control({ action: 'pause' }))
       );
     }
+  }
+
+  /** Upload status events */
+  get events(): Observable<UploadState> {
+    return this.eventsStream.asObservable();
   }
 
   /**
@@ -101,9 +102,12 @@ export class UploadxService implements OnDestroy {
    * Creates uploaders for files and adds them to the upload queue
    */
   handleFiles(files: FileList | File | File[], options = {} as UploadxOptions): void {
+    isIOS() && iOSPatch(options);
     const instanceOptions: UploadxFactoryOptions = { ...this.options, ...options };
+    store.clear(
+      (instanceOptions.storeIncompleteUploadUrl || 0) && instanceOptions.storeIncompleteHours
+    );
     this.options.concurrency = instanceOptions.concurrency;
-    isIOS() && iOSPatch(instanceOptions);
     ('name' in files ? [files] : Array.from(files)).forEach(file =>
       this.addUploaderInstance(file, instanceOptions)
     );

--- a/src/uploadx/public-api.ts
+++ b/src/uploadx/public-api.ts
@@ -12,3 +12,4 @@ export * from './lib/uploadx.directive';
 export * from './lib/options';
 export * from './lib/canceler';
 export * from './lib/id.service';
+export * from './lib/store';


### PR DESCRIPTION
Added option `storeIncompleteHours`. The default value is 24 hours.

Resume URLs will now be automatically removed from localStorage when they expire.