### PR TITLE
refactor: remove `storeIncompleteUploadUrl` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ export class AppHomeComponent {
 
 - `autoUpload` Auto start upload when files added. Default value: `true`
 
-- `storeIncompleteUploadUrl` Keep an incomplete upload URL to allow resuming after browser restart. Default value: `true`
-
 - `storeIncompleteHours` Limit upload lifetime. Default value: `24`
 
 - `chunkSize` Fixed chunk size. If not specified, the optimal size will be automatically adjusted based on the network speed.

--- a/src/app/directive-way/directive-way.component.ts
+++ b/src/app/directive-way/directive-way.component.ts
@@ -16,7 +16,6 @@ export class DirectiveWayComponent {
     endpoint: `${environment.api}/files?uploadType=uploadx`,
     token: this.authService.getAccessToken(),
     maxChunkSize: 1024 * 1024 * 8,
-    storeIncompleteUploadUrl: true,
     storeIncompleteHours: 24,
     retryConfig: {
       maxAttempts: 30,

--- a/src/uploadx/lib/options.ts
+++ b/src/uploadx/lib/options.ts
@@ -31,11 +31,6 @@ export interface UploadxOptions extends UploaderOptions {
    */
   multiple?: boolean;
   /**
-   * Keep an incomplete upload url to allow resuming after browser restart
-   * @deprecated use storeIncompleteHours = 0 to disable
-   */
-  storeIncompleteUploadUrl?: boolean;
-  /**
    * Retention time for incomplete uploads
    * @defaultValue 24
    */
@@ -48,7 +43,6 @@ export interface UploadxFactoryOptions extends UploadxOptions {
   concurrency: number;
   uploaderClass: UploaderClass;
   authorize: AuthorizeRequest;
-  storeIncompleteUploadUrl: boolean;
   storeIncompleteHours: number;
 }
 
@@ -61,7 +55,6 @@ const defaultOptions: UploadxFactoryOptions = {
     token && (req.headers['Authorization'] = `Bearer ${token}`);
     return req;
   },
-  storeIncompleteUploadUrl: true,
   storeIncompleteHours: 24
 };
 

--- a/src/uploadx/lib/uploadx.service.spec.ts
+++ b/src/uploadx/lib/uploadx.service.spec.ts
@@ -9,7 +9,6 @@ import { UploadxService } from './uploadx.service';
 
 const defaultOptions: UploadxFactoryOptions = {
   storeIncompleteHours: 1,
-  storeIncompleteUploadUrl: true,
   endpoint: '/upload',
   autoUpload: true,
   concurrency: 2,

--- a/src/uploadx/lib/uploadx.service.ts
+++ b/src/uploadx/lib/uploadx.service.ts
@@ -104,9 +104,7 @@ export class UploadxService implements OnDestroy {
   handleFiles(files: FileList | File | File[], options = {} as UploadxOptions): void {
     isIOS() && iOSPatch(options);
     const instanceOptions: UploadxFactoryOptions = { ...this.options, ...options };
-    store.clear(
-      (instanceOptions.storeIncompleteUploadUrl || 0) && instanceOptions.storeIncompleteHours
-    );
+    store.clear(instanceOptions.storeIncompleteHours);
     this.options.concurrency = instanceOptions.concurrency;
     ('name' in files ? [files] : Array.from(files)).forEach(file =>
       this.addUploaderInstance(file, instanceOptions)


### PR DESCRIPTION
set `storeIncompleteHours` to 0 to disable storing resume URLs

BREAKING CHANGE: Removed deprecated `storeIncompleteUploadUrl` option.