### PR TITLE
perf(dynamic-chunk): increase chunks time limits

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,6 +20,6 @@ export class AppComponent implements DoCheck {
   }
 
   ngDoCheck(): void {
-    console.log('change-detection ', this.changes++);
+    console.debug('change-detection count: ', this.changes++);
   }
 }

--- a/src/uploadx/lib/dynamic-chunk.spec.ts
+++ b/src/uploadx/lib/dynamic-chunk.spec.ts
@@ -1,0 +1,16 @@
+import { DynamicChunk } from './dynamic-chunk';
+
+describe('DynamicChunk', () => {
+  const init = DynamicChunk.size;
+  it('scale', () => {
+    expect(DynamicChunk.scale(0)).toEqual(init / 2);
+    expect(DynamicChunk.scale(0)).toEqual(init / 4);
+    expect(DynamicChunk.scale(Number.MAX_SAFE_INTEGER)).toEqual(init / 2);
+    expect(DynamicChunk.scale(Number.MAX_SAFE_INTEGER)).toEqual(init);
+    expect(DynamicChunk.scale(Number.MAX_SAFE_INTEGER)).toEqual(init * 2);
+    expect(DynamicChunk.scale(undefined as any)).toEqual(init * 2);
+  });
+  afterEach(() => {
+    DynamicChunk.size = init;
+  });
+});

--- a/src/uploadx/lib/dynamic-chunk.ts
+++ b/src/uploadx/lib/dynamic-chunk.ts
@@ -1,0 +1,25 @@
+const KiB = 1024;
+/**
+ * Adaptive chunk size
+ */
+export class DynamicChunk {
+  /** Maximum chunk size in bytes */
+  static maxSize = Number.MAX_SAFE_INTEGER;
+  /** Minimum chunk size in bytes */
+  static minSize = 256 * KiB;
+  /** Initial chunk size in bytes */
+  static size = 4 * (256 * KiB);
+  static minChunkTime = 8;
+  static maxChunkTime = 24;
+
+  static scale(throughput: number): number {
+    const elapsedTime = DynamicChunk.size / throughput;
+    if (elapsedTime < DynamicChunk.minChunkTime) {
+      DynamicChunk.size = Math.min(DynamicChunk.maxSize, DynamicChunk.size * 2);
+    }
+    if (elapsedTime > DynamicChunk.maxChunkTime) {
+      DynamicChunk.size = Math.max(DynamicChunk.minSize, DynamicChunk.size / 2);
+    }
+    return DynamicChunk.size;
+  }
+}

--- a/src/uploadx/lib/utils.spec.ts
+++ b/src/uploadx/lib/utils.spec.ts
@@ -1,4 +1,4 @@
-import { b64, DynamicChunk, isNumber, resolveUrl, unfunc } from './utils';
+import { b64, isNumber, resolveUrl, unfunc } from './utils';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -45,20 +45,5 @@ describe('primitives', () => {
   it('unfunc', () => {
     expect(unfunc(10, 2)).toBe(10);
     expect(unfunc((x: number) => 10 * x, 2)).toBe(20);
-  });
-});
-
-describe('DynamicChunk', () => {
-  const init = DynamicChunk.size;
-  it('scale', () => {
-    expect(DynamicChunk.scale(0)).toEqual(init / 2);
-    expect(DynamicChunk.scale(0)).toEqual(init / 4);
-    expect(DynamicChunk.scale(Number.MAX_SAFE_INTEGER)).toEqual(init / 2);
-    expect(DynamicChunk.scale(Number.MAX_SAFE_INTEGER)).toEqual(init);
-    expect(DynamicChunk.scale(Number.MAX_SAFE_INTEGER)).toEqual(init * 2);
-    expect(DynamicChunk.scale(undefined as any)).toEqual(init * 2);
-  });
-  afterEach(() => {
-    DynamicChunk.size = init;
   });
 });

--- a/src/uploadx/lib/utils.ts
+++ b/src/uploadx/lib/utils.ts
@@ -75,31 +75,6 @@ export const b64 = {
   }
 };
 
-/**
- * Adaptive chunk size
- */
-export class DynamicChunk {
-  /** Maximum chunk size in bytes */
-  static maxSize = Number.MAX_SAFE_INTEGER;
-  /** Minimum chunk size in bytes */
-  static minSize = 1024 * 256;
-  /** Initial chunk size in bytes */
-  static size = 4096 * 256;
-  static minChunkTime = 2;
-  static maxChunkTime = 8;
-
-  static scale(throughput: number): number {
-    const elapsedTime = DynamicChunk.size / throughput;
-    if (elapsedTime < DynamicChunk.minChunkTime) {
-      DynamicChunk.size = Math.min(DynamicChunk.maxSize, DynamicChunk.size * 2);
-    }
-    if (elapsedTime > DynamicChunk.maxChunkTime) {
-      DynamicChunk.size = Math.max(DynamicChunk.minSize, DynamicChunk.size / 2);
-    }
-    return DynamicChunk.size;
-  }
-}
-
 export function isIOS(): boolean {
   return /iPad|iPhone|iPod/.test(navigator.platform)
     ? true


### PR DESCRIPTION
Changed the chunk time range from 2 - 8 sec to 8 - 24 sec.
This noticeably reduces server and client overhead and decreases upload time.