### PR TITLE
fix(directive): get options from service or module

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { UploadxModule } from 'ngx-uploadx';
+import { environment } from '../environments/environment';
 import { AppComponent } from './app.component';
 import { appRoutes } from './app.routes';
 import { DirectiveWayComponent } from './directive-way/directive-way.component';
@@ -35,6 +36,8 @@ import { TusComponent } from './tus/tus.component';
     RouterModule.forRoot(appRoutes, { relativeLinkResolution: 'legacy' }),
     BrowserModule,
     UploadxModule.withConfig({
+      allowedTypes: 'image/*,video/*',
+      endpoint: `${environment.api}/files?uploadType=uploadx`,
       headers: { 'ngsw-bypass': 'true' },
       retryConfig: { maxAttempts: 5 }
     })

--- a/src/uploadx/lib/uploadx-drop.directive.spec.ts
+++ b/src/uploadx/lib/uploadx-drop.directive.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { UPLOADX_OPTIONS } from './options';
 import { UploadxDropDirective } from './uploadx-drop.directive';
-import { UploadxDirective } from './uploadx.directive';
 import { UploadxService } from './uploadx.service';
 
 @Component({
@@ -31,7 +30,7 @@ describe('Directive: UploadxDropDirective', () => {
   let serviceHandleFileListSpy: jasmine.Spy;
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [UploadxTestComponent, UploadxDirective, UploadxDropDirective],
+      declarations: [UploadxTestComponent, UploadxDropDirective],
       providers: [UploadxService, { provide: UPLOADX_OPTIONS, useValue: {} }]
     }).compileComponents();
     fixture = TestBed.createComponent(UploadxTestComponent);

--- a/src/uploadx/lib/uploadx-drop.directive.ts
+++ b/src/uploadx/lib/uploadx-drop.directive.ts
@@ -1,5 +1,4 @@
-import { ContentChild, Directive, HostBinding, HostListener } from '@angular/core';
-import { UploadxDirective } from './uploadx.directive';
+import { Directive, HostBinding, HostListener } from '@angular/core';
 import { UploadxService } from './uploadx.service';
 
 @Directive({ selector: '[uploadxDrop]' })
@@ -7,26 +6,21 @@ export class UploadxDropDirective {
   @HostBinding('class.uploadx-drop-active')
   active = false;
 
-  @ContentChild(UploadxDirective, { static: false })
-  fileInput?: UploadxDirective;
-
   constructor(private uploadService: UploadxService) {}
 
   @HostListener('drop', ['$event'])
   dropHandler(event: DragEvent): void {
-    if (event.dataTransfer && event.dataTransfer.files && event.dataTransfer.files.item(0)) {
+    if (event.dataTransfer?.files && event.dataTransfer.files.item(0)) {
       event.stopPropagation();
       event.preventDefault();
       this.active = false;
-      this.fileInput
-        ? this.fileInput.fileListener(event.dataTransfer.files)
-        : this.uploadService.handleFiles(event.dataTransfer.files);
+      this.uploadService.handleFiles(event.dataTransfer.files);
     }
   }
 
   @HostListener('dragover', ['$event'])
   onDragOver(event: DragEvent): void {
-    if (event.dataTransfer && event.dataTransfer.files) {
+    if (event.dataTransfer?.files && event.dataTransfer.files.item(0)) {
       event.dataTransfer.dropEffect = 'copy';
       event.stopPropagation();
       event.preventDefault();

--- a/src/uploadx/lib/uploadx.directive.ts
+++ b/src/uploadx/lib/uploadx.directive.ts
@@ -31,13 +31,13 @@ export class UploadxDirective implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const { multiple, allowedTypes } = this.options;
+    const { multiple, allowedTypes } = { ...this.uploadService.options, ...this.options };
     multiple !== false && this.renderer.setAttribute(this.elementRef.nativeElement, 'multiple', '');
     allowedTypes &&
       this.renderer.setAttribute(this.elementRef.nativeElement, 'accept', allowedTypes);
 
     this.uploadService.events
-      .pipe(takeWhile(_ => this.state.observers.length > 0))
+      .pipe(takeWhile(() => this.state.observers.length > 0))
       .subscribe(this.state);
   }
 


### PR DESCRIPTION
Directive should apply `multiple`, `allowedTypes` options from a module or service.