### PR TITLE
chore(app): auto-update auth token on 401 code

### DIFF
--- a/src/app/auth.service.ts
+++ b/src/app/auth.service.ts
@@ -16,7 +16,7 @@ export class AuthService {
     return of(`${new Date().getTime()}`).pipe(delay(400));
   }
 
-  async getTokenAsPromise(): Promise<string | undefined> {
+  async getTokenAsPromise(): Promise<string> {
     return `${new Date().getTime()}`;
   }
 }

--- a/src/app/directive-way/directive-way.component.ts
+++ b/src/app/directive-way/directive-way.component.ts
@@ -14,7 +14,8 @@ export class DirectiveWayComponent {
   options: UploadxOptions = {
     allowedTypes: 'image/*,video/*',
     endpoint: `${environment.api}/files?uploadType=uploadx`,
-    token: this.authService.getAccessToken(),
+    token: this.authService.getAccessToken,
+    // token: this.authService.getTokenAsPromise,
     maxChunkSize: 1024 * 1024 * 8,
     storeIncompleteHours: 24,
     retryConfig: {


### PR DESCRIPTION
Fixed example of using the authorization service.
Authorization token is now also correctly updated on 401 error.