### PR TITLE
fix: set initial progress to 0

### DIFF
--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -35,7 +35,7 @@ export abstract class Uploader implements UploadState {
   response: ResponseBody = null;
   responseStatus = 0;
   responseHeaders: Record<string, string> = {};
-  progress!: number;
+  progress = 0;
   remaining!: number;
   speed = 0;
   /** Custom headers */


### PR DESCRIPTION
For convenient usage, set initial progress to 0 to let the consumer to skip to check if progress isn't NaN.