### PR TITLE
fix: `413 Request Entity Too Large` handling

### DIFF
--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -255,6 +255,9 @@ export abstract class Uploader implements UploadState {
   }
 
   protected getChunk(): { start: number; end: number; body: Blob } {
+    if (this.responseStatus === 413) {
+      DynamicChunk.maxSize = DynamicChunk.size = Math.floor(DynamicChunk.size / 2);
+    }
     this.chunkSize =
       this.options.chunkSize === 0 ? this.size : this.options.chunkSize || DynamicChunk.size;
     const start = this.offset || 0;


### PR DESCRIPTION
Some proxies may return a 413 error if dynamic chunk size is too large

https://github.com/Chocobozzz/PeerTube/issues/4969