### PR TITLE
refactor: added `skipAuthorization` request option

### DIFF
--- a/src/uploadx/lib/interfaces.ts
+++ b/src/uploadx/lib/interfaces.ts
@@ -20,7 +20,7 @@ export interface RequestConfig {
   withCredentials?: boolean;
 }
 
-export type RequestOptions = Partial<RequestConfig>;
+export type RequestOptions = Partial<RequestConfig> & { skipAuthorization?: boolean };
 export type AuthorizeRequest = (
   req: RequestConfig,
   token?: string

--- a/src/uploadx/lib/uploader.spec.ts
+++ b/src/uploadx/lib/uploader.spec.ts
@@ -186,6 +186,21 @@ describe('Uploader', () => {
       await uploader.request({ method: 'POST', body });
       expect(onProgressSpy).toHaveBeenCalled();
     });
+
+    it('should call authorize', async () => {
+      serverStatus = 200;
+      const uploader = new MockUploader(file, {});
+      const request = spyOn<any>(uploader, '_authorize').and.callThrough();
+      await uploader.request({ method: 'GET' });
+      expect(request).toHaveBeenCalledTimes(1);
+    });
+    it('should skip authorize', async () => {
+      serverStatus = 200;
+      const uploader = new MockUploader(file, {});
+      const request = spyOn<any>(uploader, '_authorize').and.callThrough();
+      await uploader.request({ method: 'GET', skipAuthorization: true });
+      expect(request).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('prerequest', () => {

--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -185,7 +185,9 @@ export abstract class Uploader implements UploadState {
       method: requestOptions.method || 'GET',
       url: requestOptions.url || this.url
     };
-    req = await this._authorize(req, this._token);
+    if (!requestOptions.skipAuthorization) {
+      req = await this._authorize(req, this._token);
+    }
     const { body = null, headers, method, url = req.url } = (await this._prerequest(req)) || req;
     const ajaxRequestConfig: AjaxRequestConfig = {
       method,


### PR DESCRIPTION
<!-- 
Before submitting a PR, please read CONTRIBUTING.md

1. Give the pull request a descriptive title.

  Examples of good title:
    - fix(directive): get options from service
    - docs: update endpoint option description
    - feat: support for file checksum

  Examples of bad title:
    - Update docs
    - Fix: #56556
    - Update directive code

2. Ensure there are tests that cover the changes.
3. Ensure linting passes.
4. Ensure tests passes
-->

Changes proposed in this pull request:

- now it is easier not to send authorization for some requests to external URLs without using the `Authorize` option

```ts
      await this.request({
        method: 'PUT',
        body,
        url: externalUrl,
        skipAuthorization: true
      })
```
