### PR TITLE
refactor:  use `AbortSignal` for abort

### DIFF
--- a/src/uploadx/lib/ajax.ts
+++ b/src/uploadx/lib/ajax.ts
@@ -36,15 +36,16 @@ export class UploadxAjax {
     headers = {},
     url,
     responseType,
-    canceler,
+    signal,
     onUploadProgress,
     timeout = 0,
     withCredentials = false,
     validateStatus = status => status < 400 && status >= 200
   }: AjaxRequestConfig): Promise<AjaxResponse<T>> => {
-    const xhr = this.buildXhr();
-    canceler && (canceler.onCancel = () => xhr && xhr.readyState !== xhr.DONE && xhr.abort());
     return new Promise((resolve, reject) => {
+      const xhr = this.buildXhr();
+      const abortListener = () => xhr && xhr.readyState !== xhr.DONE && xhr.abort();
+      signal?.addEventListener('abort', abortListener, { once: true });
       xhr.open(method, url, true);
       xhr.timeout = timeout;
       withCredentials && (xhr.withCredentials = true);
@@ -56,6 +57,7 @@ export class UploadxAjax {
         xhr.onabort =
           evt => {
             releaseXhr(xhr);
+            signal?.removeEventListener('abort', abortListener);
             return reject({ error: evt.type, url, method });
           };
       xhr.onload = () => {
@@ -65,6 +67,7 @@ export class UploadxAjax {
           headers: this.getResponseHeaders(xhr)
         };
         releaseXhr(xhr);
+        signal?.removeEventListener('abort', abortListener);
         return validateStatus(response.status) ? resolve(response) : reject(response);
       };
       xhr.send(data);

--- a/src/uploadx/lib/interfaces.ts
+++ b/src/uploadx/lib/interfaces.ts
@@ -11,6 +11,7 @@ export type Metadata = Record<string, unknown>;
 export interface RequestConfig {
   body?: BodyInit | null;
   canceler: Canceler;
+  signal?: AbortSignal;
   headers: RequestHeaders;
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
   onUploadProgress?: (evt: ProgressEvent) => void;


### PR DESCRIPTION
<!-- 
Before submitting a PR, please read CONTRIBUTING.md

1. Give the pull request a descriptive title.

  Examples of good title:
    - fix(directive): get options from service
    - docs: update endpoint option description
    - feat: support for file checksum

  Examples of bad title:
    - Update docs
    - Fix: #56556
    - Update directive code

2. Ensure there are tests that cover the changes.
3. Ensure linting passes.
4. Ensure tests passes
-->

Changes proposed in this pull request:

- replace `Canceler` with native `AbortSignal` to abort requests since `Canceler` does not support multiple event listeners and for better compatibility

