### PR TITLE
chore(app): remove `relativeLinkResolution`

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,7 +33,7 @@ import { TusComponent } from './tus/tus.component';
     TusComponent
   ],
   imports: [
-    RouterModule.forRoot(appRoutes, { relativeLinkResolution: 'legacy' }),
+    RouterModule.forRoot(appRoutes, {}),
     BrowserModule,
     UploadxModule.withConfig({
       allowedTypes: 'image/*,video/*',


### PR DESCRIPTION


Changes proposed in this pull request:

- Remove the deprecated and incompatible with Angular 16 option `relativeLinkResolution`.

