### PR TITLE
ci: update actions to v4

### DIFF
--- a/.github/actions/cached-npm-install/action.yml
+++ b/.github/actions/cached-npm-install/action.yml
@@ -4,7 +4,7 @@ description: 'Cached npm packages installation without `package.lock.json` file 
 inputs:
   node-version:
     required: false
-    default: '18.x'
+    default: '20.x'
     description: 'Node version'
   cache-name:
     required: false
@@ -16,11 +16,11 @@ runs:
   steps:
     - name: Setup node
       id: setup-node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
     - name: Cache packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.npm

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,11 +16,11 @@ jobs:
         ng: [latest, 16]
     name: Build app with @angular/cli
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install
         uses: './.github/actions/cached-npm-install'
         with:
-          node-version: '18.x'
+          node-version: '20.x'
       - name: Build package
         run: npm run build:pkg
       - name: Build app

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -11,14 +11,14 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install
         uses: './.github/actions/cached-npm-install'
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests
         run: npx playwright test -c e2e/playwright.config.ts
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,10 +6,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install
         uses: './.github/actions/cached-npm-install'
       - name: Run linter
@@ -14,7 +14,7 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install
         uses: './.github/actions/cached-npm-install'
       - name: Run unit tests
@@ -25,7 +25,7 @@ jobs:
     name: End-to-end tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install
         uses: './.github/actions/cached-npm-install'
       - name: Run e2e tests
@@ -38,7 +38,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install
         uses: './.github/actions/cached-npm-install'
       - name: Build package


### PR DESCRIPTION


Changes proposed in this pull request:

- Upgrade Node.js 16 actions to Node.js 20 to avoid deprecation warning

