### PR TITLE
docs: fix usage example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ import { UploadxOptions, UploadState } from 'ngx-uploadx';
 
 @Component({
   selector: 'app-home',
-  templateUrl: `
-  <input type="file" [uploadx]="options" (state)="onUpload($event)">
-  `
+  template: ` <input type="file" [uploadx]="options" (state)="onUpload($event)" /> `
 })
 export class AppHomeComponent {
   options: UploadxOptions = { endpoint: `[URL]` };


### PR DESCRIPTION

Changes proposed in this pull request:

- Correct syntax in usage example

Ref #452
