### PR TITLE
refactor: change `_authorize` and `_prereques` from private to protected

### DIFF
--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -78,7 +78,9 @@ export abstract class Uploader implements UploadState {
       lastModified: file.lastModified
     };
     options.maxChunkSize && (DynamicChunk.maxSize = options.maxChunkSize);
+    /** A function that is executed before the request is sent */
     this._prerequest = options.prerequest || (req => req);
+    /** A function used to authorize the request */
     this._authorize = options.authorize || (req => req);
     this.configure(options);
   }

--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -57,9 +57,9 @@ export abstract class Uploader implements UploadState {
   abortController = new AbortController();
   /** Set HttpRequest responseType */
   responseType?: 'json' | 'text' | 'document';
+  protected _authorize: AuthorizeRequest;
+  protected _prerequest: PreRequest;
   private _eventsCount = 0;
-  private readonly _authorize: AuthorizeRequest;
-  private readonly _prerequest: PreRequest;
   private _token!: string;
 
   constructor(

--- a/uploader-examples/multipart-form-data.ts
+++ b/uploader-examples/multipart-form-data.ts
@@ -1,11 +1,12 @@
-import { resolveUrl, Uploader } from 'ngx-uploadx';
+import { AuthorizeRequest, resolveUrl, Uploader } from 'ngx-uploadx';
 
 /**
  * Multipart/form-data extended uploader for use with node-uploadx
  * @example
  *   options: UploadxOptions = {
  *     allowedTypes: 'image/*',
- *     uploaderClass: MultiPartFormData
+ *     uploaderClass: MultiPartFormData,
+ *     token: getToken
  *   };
  */
 export class MultiPartFormData extends Uploader {
@@ -31,4 +32,9 @@ export class MultiPartFormData extends Uploader {
   async getOffset(): Promise<number | undefined> {
     return 0;
   }
+
+  protected override _authorize: AuthorizeRequest = (req, token) => {
+    token && (req.headers['Authorization'] = `Basic ${token}`);
+    return req;
+  };
 }


### PR DESCRIPTION

Changes proposed in this pull request:

Change `_authorize` and `_prereques` from private to protected to easily change the authorization type in the custom uploaders.


