### PR TITLE
chore: update workspace config

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -50,18 +50,18 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "app-uploadx:build"
+            "buildTarget": "app-uploadx:build"
           },
           "configurations": {
             "production": {
-              "browserTarget": "app-uploadx:build:production"
+              "buildTarget": "app-uploadx:build:production"
             }
           }
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "app-uploadx:build"
+            "buildTarget": "app-uploadx:build"
           }
         },
         "test": {


### PR DESCRIPTION


Changes proposed in this pull request:

- Use `buildTarget` instead of deprecated `browserTarget`.



