### PR TITLE
refactor: deprecate Canceler in favor of AbortController

### DIFF
--- a/src/app/digest.ts
+++ b/src/app/digest.ts
@@ -1,16 +1,15 @@
-import { Canceler, RequestConfig, Uploader } from 'ngx-uploadx';
+import { RequestConfig, Uploader } from 'ngx-uploadx';
 
-export function readBlob(body: Blob, canceler?: Canceler): Promise<ArrayBuffer> {
+export function readBlob(body: Blob, signal?: AbortSignal): Promise<ArrayBuffer> {
   return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    if (canceler) {
-      canceler.onCancel = () => {
-        reader.abort();
-        reject('aborted');
-      };
+    if (signal?.aborted) {
+      reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+      return;
     }
+    const reader = new FileReader();
+    signal?.addEventListener('abort', () => reader.abort(), { once: true });
     reader.onload = () => resolve(reader.result as ArrayBuffer);
-    reader.onerror = reject;
+    reader.onerror = () => reject(reader.error);
     reader.readAsArrayBuffer(body);
   });
 }
@@ -34,13 +33,13 @@ export const hasher = {
   async sha(data: ArrayBuffer): Promise<ArrayBuffer> {
     return crypto.subtle.digest('SHA-1', data);
   },
-  async digestHex(body: Blob, canceler?: Canceler): Promise<string> {
-    const buffer = await readBlob(body, canceler);
+  async digestHex(body: Blob, signal?: AbortSignal): Promise<string> {
+    const buffer = await readBlob(body, signal);
     const buf = await this.sha(buffer);
     return bufferToHex(buf);
   },
-  async digestBase64(body: Blob, canceler?: Canceler): Promise<string> {
-    const buffer = await readBlob(body, canceler);
+  async digestBase64(body: Blob, signal?: AbortSignal): Promise<string> {
+    const buffer = await readBlob(body, signal);
     const hash = await this.sha(buffer);
     return bufferToBase64(hash);
   }
@@ -54,7 +53,7 @@ export async function injectTusChecksumHeader(
     if (this.chunkSize) {
       const { body, start } = this.getChunk((this.offset || 0) + this.chunkSize);
       hasher
-        .digestBase64(body, req.canceler)
+        .digestBase64(body, req.signal)
         .then(digest => {
           const key = `${body.size}-${start}`;
           hasher.prefetch[req.url] = { key, sha: digest };
@@ -67,7 +66,7 @@ export async function injectTusChecksumHeader(
     const sha =
       hasher.prefetch[req.url]?.key === key
         ? hasher.prefetch[req.url].sha
-        : await hasher.digestBase64(req.body, req.canceler);
+        : await hasher.digestBase64(req.body, req.signal);
     Object.assign(req.headers, { 'Upload-Checksum': `sha1 ${sha}` });
   }
   return req;
@@ -80,7 +79,7 @@ export async function injectDigestHeader(
   if (hasher.isSupported && req.body instanceof Blob) {
     if (this.chunkSize) {
       const { body, start } = this.getChunk((this.offset || 0) + this.chunkSize);
-      hasher.digestBase64(body, req.canceler).then(digest => {
+      hasher.digestBase64(body, req.signal).then(digest => {
         const key = `${body.size}-${start}`;
         hasher.prefetch[req.url] = { key, sha: digest };
       });
@@ -89,7 +88,7 @@ export async function injectDigestHeader(
     const sha =
       hasher.prefetch[req.url]?.key === key
         ? hasher.prefetch[req.url].sha
-        : await hasher.digestBase64(req.body, req.canceler);
+        : await hasher.digestBase64(req.body, req.signal);
     Object.assign(req.headers, { Digest: `sha=${sha}` });
   }
   return req;

--- a/src/uploadx/lib/canceler.ts
+++ b/src/uploadx/lib/canceler.ts
@@ -1,6 +1,7 @@
 /**
  * Allows canceling some operation by calling cancel().
  * onCancel callback can be used to execute cleanup logic when cancel is called.
+ * @deprecated Use AbortController instead. Will be removed in next major version.
  */
 export class Canceler {
   /**

--- a/src/uploadx/lib/interfaces.ts
+++ b/src/uploadx/lib/interfaces.ts
@@ -10,7 +10,7 @@ export type Metadata = Record<string, unknown>;
 
 export interface RequestConfig {
   body?: BodyInit | null;
-  canceler: Canceler;
+  canceler?: Canceler;
   signal?: AbortSignal;
   headers: RequestHeaders;
   method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';

--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -1,5 +1,4 @@
 import { Ajax, AjaxRequestConfig } from './ajax';
-import { Canceler } from './canceler';
 import { DynamicChunk } from './dynamic-chunk';
 import {
   AuthorizeRequest,
@@ -53,7 +52,6 @@ export abstract class Uploader implements UploadState {
   offset?: number;
   /** Retries handler */
   retry: RetryHandler;
-  canceler = new Canceler();
   abortController = new AbortController();
   /** Set HttpRequest responseType */
   responseType?: 'json' | 'text' | 'document';
@@ -191,7 +189,6 @@ export abstract class Uploader implements UploadState {
     const signal = requestOptions.signal || this.abortController.signal;
     let req: RequestConfig = {
       body: requestOptions.body || null,
-      canceler: this.canceler,
       signal,
       headers: { ...this.headers, ...requestOptions.headers },
       method: requestOptions.method || 'GET',
@@ -208,7 +205,6 @@ export abstract class Uploader implements UploadState {
       data: body,
       responseType: this.options.responseType ?? this.responseType,
       withCredentials: !!this.options.withCredentials,
-      canceler: this.canceler,
       signal,
       validateStatus: () => true,
       timeout: this.retry.config.timeout
@@ -257,7 +253,6 @@ export abstract class Uploader implements UploadState {
   protected abort(): void {
     this.offset = undefined;
     this.abortController.abort();
-    this.canceler.cancel();
   }
 
   protected async cancel(): Promise<void> {


### PR DESCRIPTION


Changes proposed in this pull request:

- Deprecate Canceler, replace with AbortController/AbortSignal across the codebase.



