### PR TITLE
chore: remove deprecated baseUrl from tsconfig.json

### DIFF
--- a/scripts/build-app.js
+++ b/scripts/build-app.js
@@ -68,7 +68,11 @@ async function build(cliTag = 'latest') {
 
 async function processing() {
   const args = process.argv.slice(2);
-  const cmd = args[0].trim();
+  const cmd = args[0]?.trim();
+  if (!cmd) {
+    console.error('Please specify Angular CLI version/tag to build.');
+    process.exit(1);
+  }
   let exitCode = 0;
   try {
     await build(cmd);

--- a/src/uploadx/tsconfig.lib.json
+++ b/src/uploadx/tsconfig.lib.json
@@ -1,8 +1,7 @@
 {
   "angularCompilerOptions": {
     "compilationMode": "partial",
-    "strictTemplates": true,
-    "enableResourceInlining": true
+    "strictTemplates": true
   },
   "buildOnSave": false,
   "compileOnSave": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
@@ -20,7 +19,7 @@
     "module": "es2022",
     "lib": ["es2022", "dom"],
     "paths": {
-      "ngx-uploadx": ["src/uploadx/"]
+      "ngx-uploadx": ["./src/uploadx/"]
     }
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove deprecated baseUrl option
- Add input validation to build-app.js
