### PR TITLE
feat: detect stalled uploads and improve retry logic

### DIFF
--- a/src/uploadx/lib/retry-handler.spec.ts
+++ b/src/uploadx/lib/retry-handler.spec.ts
@@ -27,14 +27,14 @@ describe('RetryHandler', () => {
     expect(retry.kind(500)).toBe(ErrorType.Fatal);
   });
 
-  it('observe(offset)', () => {
+  it('checkForStall resets attempts on new value', () => {
     retry.config.maxAttempts = 2;
-    retry.observe('same value');
-    expect(retry.kind(500)).toBe(ErrorType.Retryable);
-    retry.observe('same value');
-    expect(retry.kind(500)).toBe(ErrorType.Retryable);
-    retry.observe('same value');
-    expect(retry.kind(500)).toBe(ErrorType.Fatal);
+    retry.checkForStall('value1');
+    expect(retry.attempts).toBe(0);
+    retry.kind(500);
+    expect(retry.attempts).toBe(1);
+    retry.checkForStall('value2'); // new value resets attempts
+    expect(retry.attempts).toBe(0);
   });
 
   it('wait()', async () => {
@@ -60,5 +60,28 @@ describe('RetryHandler', () => {
     await wait.then(() => {
       expect(retry.kind(500)).toBe(ErrorType.Retryable);
     });
+  });
+
+  it('should detect stalled upload (same offset)', () => {
+    expect(retry.checkForStall(0)).toBe(false);
+    expect(retry.checkForStall(0)).toBe(false);
+    expect(retry.checkForStall(0)).toBe(false);
+    expect(retry.checkForStall(0)).toBe(true);
+  });
+
+  it('should reset stalled counter when offset changes', () => {
+    expect(retry.checkForStall(0)).toBe(false);
+    expect(retry.checkForStall(0)).toBe(false);
+    expect(retry.checkForStall(100)).toBe(false);
+    expect(retry.checkForStall(100)).toBe(false);
+    expect(retry.checkForStall(100)).toBe(false);
+    expect(retry.checkForStall(100)).toBe(true);
+  });
+
+  it('should not count undefined as stalled', () => {
+    expect(retry.checkForStall(undefined)).toBe(false);
+    expect(retry.checkForStall(undefined)).toBe(false);
+    expect(retry.checkForStall(undefined)).toBe(false);
+    expect(retry.checkForStall(undefined)).toBe(false);
   });
 });

--- a/src/uploadx/lib/retry-handler.ts
+++ b/src/uploadx/lib/retry-handler.ts
@@ -55,6 +55,7 @@ export class RetryHandler {
   public attempts = 0;
   config: Required<RetryConfig>;
   private observedValue?: string | number;
+  private repeatCount = 0;
   cancel: () => void = () => {};
 
   constructor(configOptions: RetryConfig = {}) {
@@ -101,11 +102,28 @@ export class RetryHandler {
   }
 
   /**
-   * Observes value to reset retry attempts counter
-   * @param value - Value to observe
+   * @deprecated Use checkForStall instead
    */
   observe(value?: string | number): void {
-    this.observedValue !== value && (this.attempts = 0);
-    this.observedValue = value;
+    this.checkForStall(value);
+  }
+
+  /**
+   * Check if upload is stalled
+   */
+  checkForStall(value?: string | number): boolean {
+    if (value === undefined) {
+      this.repeatCount = 0;
+      this.observedValue = undefined;
+      return false;
+    }
+    if (this.observedValue === value) {
+      this.repeatCount++;
+    } else {
+      this.repeatCount = 0;
+      this.observedValue = value;
+      this.attempts = 0;
+    }
+    return this.repeatCount >= 3;
   }
 }

--- a/src/uploadx/lib/retry-handler.ts
+++ b/src/uploadx/lib/retry-handler.ts
@@ -52,6 +52,7 @@ const defaultRetryConfig: Required<RetryConfig> = {
  * Retryable ErrorHandler
  */
 export class RetryHandler {
+  static readonly STALL_THRESHOLD = 3;
   public attempts = 0;
   config: Required<RetryConfig>;
   private observedValue?: string | number;
@@ -124,6 +125,6 @@ export class RetryHandler {
       this.observedValue = value;
       this.attempts = 0;
     }
-    return this.repeatCount >= 3;
+    return this.repeatCount >= RetryHandler.STALL_THRESHOLD;
   }
 }

--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -142,11 +142,11 @@ export abstract class Uploader implements UploadState {
             : await this.getOffset();
         }
         if (this.retry.checkForStall(this.offset)) {
-          this.status = 'error';
           this.response = {
             error: 'stalled',
-            message: 'No offset update received — upload is stalled'
+            message: `No offset update received after ${RetryHandler.STALL_THRESHOLD} attempts — upload is stalled (offset: ${this.offset})`
           };
+          this.status = 'error';
           return;
         }
         if (this.offset === this.size) {

--- a/src/uploadx/lib/uploader.ts
+++ b/src/uploadx/lib/uploader.ts
@@ -141,7 +141,14 @@ export abstract class Uploader implements UploadState {
             ? await this.sendFileContent()
             : await this.getOffset();
         }
-        this.retry.observe(this.offset);
+        if (this.retry.checkForStall(this.offset)) {
+          this.status = 'error';
+          this.response = {
+            error: 'stalled',
+            message: 'No offset update received — upload is stalled'
+          };
+          return;
+        }
         if (this.offset === this.size) {
           this.remaining = 0;
           this.progress = 100;

--- a/src/uploadx/lib/uploaderx.ts
+++ b/src/uploadx/lib/uploaderx.ts
@@ -54,7 +54,10 @@ export class UploaderX extends Uploader {
 
   protected getOffsetFromResponse(): number | undefined {
     const range = this.getValueFromResponse('Range');
-    return range ? getRangeEnd(range) + 1 : undefined;
+    if (range) {
+      return getRangeEnd(range) + 1;
+    }
+    return this.responseStatus === 308 ? 0 : undefined;
   }
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Add `checkForStall()` to detect stalled uploads
- Handle 308 responses without `Range` header by restarting from offset 0


