### PR TITLE
chore: update TypeScript and Vitest configs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "ignorePatterns": ["projects/**/*"],
+  "ignorePatterns": ["vitest.config.ts"],
   "overrides": [
     {
       "files": ["*.ts"],

--- a/src/uploadx/lib/ajax.spec.ts
+++ b/src/uploadx/lib/ajax.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { describe, beforeEach, it, expect } from 'vitest';
 import { UploadxAjax } from './ajax';
 
 const data = { key0: '0', key1: '1' };

--- a/src/uploadx/lib/retry-handler.spec.ts
+++ b/src/uploadx/lib/retry-handler.spec.ts
@@ -1,4 +1,3 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ErrorType, RetryHandler } from './retry-handler';
 
 describe('RetryHandler', () => {

--- a/src/uploadx/lib/store.spec.ts
+++ b/src/uploadx/lib/store.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, expect, it } from 'vitest';
 import { Store } from './store';
 
 describe('Store', () => {

--- a/src/uploadx/lib/tus.spec.ts
+++ b/src/uploadx/lib/tus.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi, type Mock } from 'vitest';
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { type Mock } from 'vitest';
 import { Ajax } from './ajax';
 import { Tus } from './tus';
 

--- a/src/uploadx/lib/uploader.spec.ts
+++ b/src/uploadx/lib/uploader.spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Ajax } from './ajax';
 import { DynamicChunk } from './dynamic-chunk';
 import { UploaderOptions, UploadStatus } from './interfaces';

--- a/src/uploadx/lib/uploaderx.spec.ts
+++ b/src/uploadx/lib/uploaderx.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi, type Mock } from 'vitest';
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { type Mock } from 'vitest';
 import { Ajax } from './ajax';
 import { getRangeEnd, UploaderX } from './uploaderx';
 

--- a/src/uploadx/lib/uploadx-drop.directive.spec.ts
+++ b/src/uploadx/lib/uploadx-drop.directive.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { type Mock } from 'vitest';
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';

--- a/src/uploadx/lib/uploadx.directive.spec.ts
+++ b/src/uploadx/lib/uploadx.directive.spec.ts
@@ -1,7 +1,7 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { type Mock } from 'vitest';
 import { UploadxControlEvent } from './interfaces';
 import { UPLOADX_OPTIONS } from './options';
 import { UploadxDirective } from './uploadx.directive';

--- a/src/uploadx/lib/uploadx.service.spec.ts
+++ b/src/uploadx/lib/uploadx.service.spec.ts
@@ -5,7 +5,6 @@ import { UploadAction } from './interfaces';
 import { UploadxOptions } from './options';
 import { UploaderX } from './uploaderx';
 import { UploadxService } from './uploadx.service';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 class MockUploader extends UploaderX {
   async upload(): Promise<void> {

--- a/src/uploadx/lib/utils.spec.ts
+++ b/src/uploadx/lib/utils.spec.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import { b64, isNumber, resolveUrl, unfunc } from './utils';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -2,9 +2,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "outDir": "./out-tsc/app",
     "types": []
   },
   "files": ["src/main.ts", "src/polyfills.ts"],
-  "include": ["src/**/*.d.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts"]
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,9 @@
 /* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts", "e2e/**/*.ts", "uploader-examples/**/*.ts", "vitest.config.ts"]
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "e2e/**/*.ts", "uploader-examples/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "strict": true,
@@ -22,6 +21,15 @@
       "ngx-uploadx": ["./src/uploadx/"]
     }
   },
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -2,6 +2,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "outDir": "./out-tsc/spec",
     "types": ["vitest/globals"]
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    exclude: ['e2e/**/*'],
     globals: true,
     environment: 'happy-dom',
     testTimeout: 10000,


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove vitest imports from spec files (use globals instead)
- Add TypeScript project references
- Exclude e2e tests from Vitest runner
